### PR TITLE
EC2 Metadata Scraping

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,46 @@
+# Development
+
+`metascrape` was developed on Python 3.7, and uses `zc.buildout` for dependency management and project dependency
+isolation.
+
+## Getting Started
+
+To setup a local development environment, use one of the following methods:
+
+ - Use Vagrant: `vagrant up`
+ - Use Docker: `docker build -t naftulikay/metascrape:latest .`
+ - Use a local Python development environment.
+
+If you're using Vagrant or a local Python development environment, run the following to set up the project:
+
+```
+$ pip install --user -r requirements.txt
+$ buildout
+```
+
+If you're using `virtualenv`, you can omit the `--user` above.
+
+## Metadata Service Proxying
+
+SSH port-forwarding can be used to expose a remote server's metadata service locally:
+
+```
+$ ssh -L 8080:169.254.169.254:80 my-remote-host
+```
+
+This will expose the metadata service on local port 8080.
+
+If you need to test from within Docker or Vagrant, you will likely need to forward the port again into the container
+or VM.
+
+For Vagrant:
+
+```
+$ vagrant ssh -- -R 8080:localhost:8080
+```
+
+This will forward port 8080 on localhost in the VM to 8080 on the host, which is where the previous command proxies
+the metadata service to.
+
+For Docker, the simplest way to forward is to run the container as `--net host`, but be aware that `--net host` has
+many dangerous security implications for running in any other environment than a development environment.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # using a specific IP.
   config.vm.network "private_network", type: "dhcp"
 
+# forward AWS environment variables across the wire
+  config.ssh.forward_env = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
+
   # Tweak the VMs configuration.
   config.vm.provider "virtualbox" do |vb|
     vb.cpus = Etc.nprocessors

--- a/etc/terraform/.gitignore
+++ b/etc/terraform/.gitignore
@@ -1,0 +1,8 @@
+aws/keys/*
+azure/keys/*
+gcp/keys/*
+
+.terraform
+*.tfstate
+*.tfstate.backup*
+*.tfstate.lock*

--- a/etc/terraform/aws/Makefile
+++ b/etc/terraform/aws/Makefile
@@ -1,0 +1,58 @@
+#!/usr/bin/make -f
+
+SHELL:=$(shell which bash)
+
+SSH_METHOD?=private
+
+ifeq ($(SSH_METHOD),private)
+	SSH_HOST_IP_OUTPUT=private_ip
+else
+	SSH_HOST_IP_OUTPUT=public_ip
+endif
+
+REGION?=us-east-1
+
+gen_keys:
+	@mkdir -p keys/
+	@if [ ! -e keys/ssh ]; then \
+		ssh-keygen -b 4096 -t rsa -f keys/ssh -P '' ; \
+	fi
+
+validate:
+ifndef VPC_ID
+	$(error VPC_ID must be set.)
+endif
+ifndef SUBNET_ID
+	$(error SUBNET_ID must be set.)
+endif
+
+init:
+	@if ! terraform init >/dev/null 2>/dev/null ; then \
+		terraform init ; \
+	fi
+
+plan: gen_keys validate init
+	@terraform plan -var vpc_id=$(VPC_ID) -var subnet_id=$(SUBNET_ID) -var region=$(REGION) \
+		-var ssh_public_key="$(shell cat keys/ssh.pub)"
+
+apply: gen_keys validate init
+	@terraform apply -auto-approve -var vpc_id=$(VPC_ID) -var subnet_id=$(SUBNET_ID) -var region=$(REGION) \
+		-var ssh_public_key="$(shell cat keys/ssh.pub)"
+
+destroy: gen_keys validate init
+	@terraform destroy -force -var vpc_id=$(VPC_ID) -var subnet_id=$(SUBNET_ID) -var region=$(REGION) \
+		-var ssh_public_key="$(shell cat keys/ssh.pub)"
+
+output: init
+	@terraform output
+
+refresh: init
+	@terraform refresh
+
+shell:
+	@ssh -i keys/ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l $(shell echo "core") \
+		$(shell terraform output $(SSH_HOST_IP_OUTPUT))
+
+tunnel:
+	@ssh -i keys/ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -L 8080:169.254.169.254:80 \
+		-l $(shell echo "core") $(shell terraform output $(SSH_HOST_IP_OUTPUT))

--- a/etc/terraform/aws/README.md
+++ b/etc/terraform/aws/README.md
@@ -1,0 +1,19 @@
+# Terraform for Testing in AWS
+
+This Terraform project generates a key pair locally, builds a security group and EC2 instance, and provides utilities
+to make building this relatively easy using a Makefile.
+
+## Variables
+
+There are a few variables that must be defined for Terraform actions to work when using the Makefile:
+
+ - `REGION`: if you're not in `us-east-1`, pass this value to set your region.
+ - `SSH_METHOD`: by default, we use the private IP to shell into the host, set to `public` to use the _public_ IP.
+ - `SUBNET_ID`: a subnet id to launch the instance into.
+ - `VPC_ID`: a VPC id to launch the instance into.
+
+Example:
+
+```shell
+make -sC etc/terraform/aws VPC_ID=vpc-deadbeef SUBNET_ID=subnet-deadbeefcafebabe plan
+```

--- a/etc/terraform/aws/main.tf
+++ b/etc/terraform/aws/main.tf
@@ -1,0 +1,114 @@
+# AWS EC2 Instance for Testing
+
+provider "aws" {
+  region = "${var.region}"
+}
+
+variable "allowed_cidr_ranges" {
+  type = "list"
+  default = ["10.0.0.0/8", "192.168.0.0/16"]
+}
+
+variable "region" { default = "us-east-1" }
+variable "ssh_public_key" {}
+variable "subnet_id" {}
+variable "vpc_id" {}
+
+data "aws_ami" "coreos_stable" {
+  most_recent = "true"
+
+  filter {
+    name = "name"
+    values = ["CoreOS-stable-*-hvm"]
+  }
+
+  filter {
+    name = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  # coreos
+  owners = ["595879546273"]
+}
+
+data "template_file" "cloud_init" {
+  template = "${file("${path.module}/templates/cloud-config.yml.tpl")}"
+
+  vars = {
+    hostname = "metascrape-aws-tester-${random_string.id.result}"
+  }
+}
+
+resource "random_string" "id" {
+  length = 8
+  upper = false
+  lower = true
+  number = true
+  special = false
+}
+
+resource "aws_key_pair" "default" {
+  key_name = "metascrape-aws-tester-${random_string.id.result}"
+  public_key = "${var.ssh_public_key}"
+}
+
+resource "aws_instance" "default" {
+  ami = "${data.aws_ami.coreos_stable.id}"
+  instance_initiated_shutdown_behavior = "terminate"
+  instance_type = "t2.micro"
+  key_name = "${aws_key_pair.default.id}"
+  vpc_security_group_ids = ["${aws_security_group.default.id}"]
+  subnet_id = "${var.subnet_id}"
+
+  user_data = "${data.template_file.cloud_init.rendered}"
+
+  credit_specification {
+    cpu_credits = "unlimited"
+  }
+
+  tags = {
+    Name = "metascrape-aws-tester-${random_string.id.result}"
+  }
+}
+
+resource "aws_security_group" "default" {
+  name = "metascrape-aws-tester-${random_string.id.result}"
+  description = "Temporary security group for testing metascrape."
+  vpc_id = "${var.vpc_id}"
+}
+
+resource "aws_security_group_rule" "ingress_ssh" {
+  type = "ingress"
+  from_port = 22
+  to_port = 22
+  protocol = "tcp"
+  cidr_blocks = "${var.allowed_cidr_ranges}"
+
+  security_group_id = "${aws_security_group.default.id}"
+}
+
+resource "aws_security_group_rule" "ingress_icmp" {
+  type = "ingress"
+  from_port = -1
+  to_port = -1
+  protocol = "icmp"
+  cidr_blocks = "${var.allowed_cidr_ranges}"
+
+  security_group_id = "${aws_security_group.default.id}"
+}
+
+resource "aws_security_group_rule" "egress" {
+  type = "egress"
+  from_port = 0
+  to_port = 65535
+  protocol = "all"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.default.id}"
+}
+
+output "instance_id" { value = "${aws_instance.default.id}" }
+output "private_ip" { value = "${aws_instance.default.private_ip}" }
+output "public_ip" { value = "${aws_instance.default.public_ip}" }
+output "security_group_id" { value = "${aws_security_group.default.id}" }
+output "ssh_user" { value = "core" }

--- a/etc/terraform/aws/templates/cloud-config.yml.tpl
+++ b/etc/terraform/aws/templates/cloud-config.yml.tpl
@@ -1,0 +1,7 @@
+#cloud-config
+
+hostname: ${hostname}
+
+coreos:
+  update:
+    reboot-strategy: off

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,6 @@
 ---
+- name: terraform
+  src: naftulikay.terraform
 - name: vagrant-docker
   src: naftulikay.vagrant-docker
 - name: vagrant-python-dev

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     install_requires = [
         "setuptools",
         "scrapy",
+        "tzlocal",
     ],
     entry_points = {
         "console_scripts": [

--- a/src/metascrape/__init__.py
+++ b/src/metascrape/__init__.py
@@ -1,2 +1,2 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-

--- a/src/metascrape/cli.py
+++ b/src/metascrape/cli.py
@@ -1,8 +1,71 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+from metascrape.spiders import EC2Spider
+from metascrape.utils import LoggingFormatter
+
+from scrapy.crawler import CrawlerProcess
+
+import argparse
+import logging
+import scrapy
+
+
 def main():
-    print("Hello world!")
+    parser = argparse.ArgumentParser(
+        prog='metascrape',
+        description="A scraper in Python/Scrapy for extracting cloud provider instance metadata.",
+    )
+
+    parser.add_argument('-H', '--host', default='169.254.169.254',
+        help="The host where the instance metadata service lives.")
+    parser.add_argument('-o', '--output', default="metadata.json",
+        help="The output file to store scraped information in.")
+    parser.add_argument('-p', '--port', default=80, type=int,
+        help="The port where the instance metadata service is listening.")
+    parser.add_argument('-v', action='count', dest='verbosity', default=0,
+        help="Set logging verbosity. Pass multiple times to increase verbosity.")
+
+    args = parser.parse_args()
+
+    # setup logging
+    setup_logging(args.verbosity)
+
+    logger = logging.getLogger("metascrape")
+    logger.info("Starting scraper...")
+
+    scrape(args.host, args.port, args.output)
+
+
+def setup_logging(verbosity):
+    """Setup and configure Python logging."""
+    logging.addLevelName(logging.WARNING, "WARN")
+
+    console = logging.StreamHandler()
+    console.setFormatter(LoggingFormatter(
+        fmt="%(asctime)s [%(levelname)-5s] %(name)s: %(message)s",
+    ))
+
+    logging.getLogger(None).setLevel(logging.WARNING)
+    logging.getLogger(None).addHandler(console)
+
+    logging.getLogger('metascrape').setLevel(max(logging.WARNING - (verbosity * 10), 0))
+
+
+def scrape(host, port, output_file):
+    """Execute the scraper on the given host and port."""
+    process = CrawlerProcess({
+        'BOT_NAME': 'metascrape',
+        'CONCURRENT_REQUESTS_PER_DOMAIN': 10,
+        'ITEM_PIPELINES': {
+            'metascrape.pipelines.JSONItemPipeline': 1000
+        },
+        'JSON_OUTPUT_FILE': output_file,
+        'LOG_ENABLED': False,
+    })
+
+    process.crawl(EC2Spider, metadata_host=host, metadata_port=port)
+    process.start()
 
 
 if __name__ == "__main__":

--- a/src/metascrape/exceptions/__init__.py
+++ b/src/metascrape/exceptions/__init__.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+
+class WrongServiceException(Exception):
+    """
+    An exception thrown when attempting to crawl the wrong metadata service.
+
+    If, say, the EC2 crawler attempts to crawl the GCP metadata service, this exception will be raised.
+    """

--- a/src/metascrape/items/__init__.py
+++ b/src/metascrape/items/__init__.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from ipaddress import IPv4Address
+
+import json
+import re
+import scrapy
+import string
+
+
+class Matchers(object):
+
+    AWS_ACCOUNT_ID = re.compile(r'\b(?P<account_id>\d{12})\b')
+
+    AWS_IDENTIFIER = re.compile(r'\b(?P<aws_id>(?P<type>[a-z]{1,6})-(?P<id>[0-9a-f]{8,32}))\b')
+
+    EC2_HOSTNAME_PREFIX = re.compile(r'\b(?P<type>ec2|ip)-(?P<octet_0>\d{1,3})-(?P<octet_1>\d{1,3})-(?P<octet_2>\d{1,3})-(?P<octet_3>\d{1,3})\.(?P<region>[^.]+)\.compute\.(?P<root_domain>amazonaws\.com|internal)\b')
+
+    IPV4_ADDRESS = re.compile(r'\b(?P<ipv4_address>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\b', re.I)
+
+    MAC_ADDRESS = re.compile(r'\b(?P<mac_address>[0-9a-f]{2}:[0-9a-f]{2}:[0-9a-f]{2}:[0-9a-f]{2}:[0-9a-f]{2}:[0-9a-f]{2})\b')
+
+
+class Route(scrapy.Item):
+    """An item representing an available route for the service."""
+
+    """The path of the given route."""
+    path = scrapy.Field()
+
+    """The headers returned by the given route."""
+    headers = scrapy.Field()
+
+    """The raw response."""
+    response = scrapy.Field()
+
+    """The response encoding, either 'text' or 'base64'."""
+    response_encoding = scrapy.Field()
+
+    @property
+    def path_postfix(self):
+        """Return the path postfix without the API version prepended."""
+        path = self["path"]
+        path_components = list(filter(lambda pc: len(pc) > 0, path.split("/")))
+
+        return "{}{}".format("/".join(path_components[1:]), "/" if path.endswith("/") else "")
+
+    def sanitize(self):
+        """Sanitize this route's data to redact private information."""
+        self._sanitize_ip_addresses()
+        self._sanitize_mac_addresses()
+        self._sanitize_account_ids()
+        self._sanitize_host_name()
+        self._sanitize_aws_identifiers()
+        self._sanitize_iam_credentials()
+        self._sanitize_instance_identity()
+
+    def _sanitize_ip_addresses(self):
+        """Sanitize public and private IP addresses in this route."""
+        path, response = self["path"], self["response"]
+
+        def ip_replace(match):
+            addr = IPv4Address(match.group('ipv4_address'))
+            octets = list(map(lambda o: int(o), str(addr).split('.')))
+
+            if addr.is_private:
+                return "10.0.0.{}".format(0 if octets[-1] == 0 else 1)
+            elif addr.is_global:
+                return "1.1.1.{}".format(0 if octets[-1] == 0 else 1)
+            else:
+                return str(addr)
+
+        self["path"], self["response"] = Matchers.IPV4_ADDRESS.sub(ip_replace, path), \
+                Matchers.IPV4_ADDRESS.sub(ip_replace, response)
+
+    def _sanitize_mac_addresses(self):
+        """Sanitize MAC addresses in this route."""
+        path, response = self["path"], self["response"]
+
+        def mac_replace(match):
+            return "01:23:45:67:89:ab"
+
+        self["path"], self["response"] = Matchers.MAC_ADDRESS.sub(mac_replace, path), \
+                Matchers.MAC_ADDRESS.sub(mac_replace, response)
+
+    def _sanitize_host_name(self):
+        """Sanitize the host name, which reflects the actual IP."""
+        path, response = self["path"], self["response"]
+
+        if path.split("/")[-1] not in ["hostname", "local-hostname", "public-hostname"]:
+            return
+
+        match = Matchers.EC2_HOSTNAME_PREFIX.search(response)
+
+        if not match:
+            raise Exception("Unable to sanitize hostname: {}".format(response))
+
+        host_type = match.group('type')
+        octet_0, octet_1, octet_2, octet_3 = match.group('octet_0'), match.group('octet_1'), match.group('octet_2'), \
+                match.group('octet_3')
+
+        postfix = ".".join(response.split('.')[1:])
+
+        if host_type == "ec2":
+            # public host
+            octet_0, octet_1, octet_2, octet_3 = "1", "1", "1", "1"
+        else:
+            # private host
+            octet_0, octet_1, octet_2, octet_3 = "10", "0", "0", "1"
+
+        self["response"] = "{}-{}-{}-{}-{}.{}".format(host_type, octet_0, octet_1, octet_2, octet_3, postfix)
+
+
+    def _sanitize_account_ids(self):
+        """Sanitize AWS account IDs in this route."""
+        path, response = self["path"], self["response"]
+
+        def account_replace(match):
+            return "012345678901"
+
+        self["path"], self["response"] = Matchers.AWS_ACCOUNT_ID.sub(account_replace, path), \
+                Matchers.AWS_ACCOUNT_ID.sub(account_replace, response)
+
+    def _sanitize_aws_identifiers(self):
+        """Sanitize identifiers for AWS objects such as EC2 instance ids."""
+        replacer = "0123456789abcdef"
+
+        path, response = self["path"], self["response"]
+
+        def aws_id_replace(match):
+            resource_type, resource_id = match.group('type'), match.group('id')
+
+            return "{}-{}".format(resource_type, "".join(
+                [replacer[i % len(replacer)] for i in range(len(resource_id))]
+            ))
+
+        self["path"], self["response"] = Matchers.AWS_IDENTIFIER.sub(aws_id_replace, path), \
+                Matchers.AWS_IDENTIFIER.sub(aws_id_replace, response)
+
+    def _sanitize_iam_credentials(self):
+        """Sanitize sensitive IAM credentials."""
+        path, response = self["path"], self["response"]
+
+        if not path.endswith("/meta-data/identity-credentials/ec2/security-credentials/ec2-instance"):
+           return
+
+        # okay so now we've reached our IAM credentials.
+        response = json.loads(response)
+
+        response["AccessKeyId"] = "A" * 20
+        response["SecretAccessKey"] = "B" * 40
+        response["Token"] = "C" * 676
+
+        self["response"] = json.dumps(response, indent=4)
+
+    def _sanitize_instance_identity(self):
+        """Sanitize instance identity cryptographic data."""
+        # the format of these items is complicated, see issue #2
+        path, response = self["path"], self["response"]
+
+        if path.endswith("/dynamic/instance-identity/pkcs7"):
+            response = "A" * 828
+
+        if path.endswith("/dynamic/instance-identity/rsa2048"):
+            response = "B" * 1063
+
+        if path.endswith("/dynamic/instance-identity/signature"):
+            response = "C" * 128
+
+        self["path"], self["response"] = path, response

--- a/src/metascrape/items/tests.py
+++ b/src/metascrape/items/tests.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from metascrape.items import Matchers, Route
+
+import unittest
+
+
+class MatcherTestCase(unittest.TestCase):
+    """Regular expression test case for EC2 route objects."""
+
+    def test_aws_account_id(self):
+        """Test AWS account ID matching."""
+        for account in ['012345678901', '109876543210']:
+            self.assertIsNotNone(Matchers.AWS_ACCOUNT_ID.search(account))
+
+        for account in ['123456', '012345678901234567890a']:
+            self.assertIsNone(Matchers.AWS_ACCOUNT_ID.search(account))
+
+    def test_aws_identifier(self):
+        """Test AWS identifier matching."""
+        for id in ["ami-0123456789abdef01", "eni-0123456789abdef01", "i-0123456789abdef01", "r-0123456789abdef01", \
+                "sg-0123456789abdef01", "subnet-0123456789abdef01", "vpc-01234567"]:
+            self.assertIsNotNone(Matchers.AWS_IDENTIFIER.search(id))
+
+        for id in ["i-1234", "I-01234567"]:
+            self.assertIsNone(Matchers.AWS_IDENTIFIER.search(id))
+
+    def test_ec2_hostname_prefix(self):
+        """Test EC2 hostname prefix matching."""
+        public = "ec2-1-1-1-1.us-west-2.compute.amazonaws.com"
+        private = "ip-10-0-0-1.us-west-2.compute.internal"
+
+        # test public
+        self.assertIsNotNone(Matchers.EC2_HOSTNAME_PREFIX.search(public))
+
+        match = Matchers.EC2_HOSTNAME_PREFIX.search(public)
+
+        self.assertEqual("ec2", match.group('type'))
+        self.assertEqual("1", match.group('octet_0'))
+        self.assertEqual("1", match.group('octet_1'))
+        self.assertEqual("1", match.group('octet_2'))
+        self.assertEqual("1", match.group('octet_3'))
+
+        # test private
+        self.assertIsNotNone(Matchers.EC2_HOSTNAME_PREFIX.search(private))
+
+        match = Matchers.EC2_HOSTNAME_PREFIX.search(private)
+
+        self.assertEqual("ip", match.group('type'))
+        self.assertEqual("10", match.group('octet_0'))
+        self.assertEqual("0", match.group('octet_1'))
+        self.assertEqual("0", match.group('octet_2'))
+        self.assertEqual("1", match.group('octet_3'))
+
+    def test_ipv4_address(self):
+        """Test IPv4 address matching."""
+        for addr in ["0.0.0.0", "255.255.255.255", "127.0.0.1", "10.0.0.1"]:
+            self.assertIsNotNone(Matchers.IPV4_ADDRESS.search(addr))
+
+        for addr in ['bc', '10.0.0', '10.10.10.']:
+            self.assertIsNone(Matchers.IPV4_ADDRESS.search(addr))
+
+    def test_mac_address(self):
+        """Test MAC address matching."""
+        for mac in ['00:00:00:00:00:00', 'af:10:23:70:ba:cd']:
+            self.assertIsNotNone(Matchers.MAC_ADDRESS.search(mac))
+
+        for mac in ['ze:do:gi:is:de:ad']:
+            self.assertIsNone(Matchers.MAC_ADDRESS.search(mac))
+
+
+class RouteTestCase(unittest.TestCase):
+    """Tests cases against the Route item."""
+
+    def test_path_postfix(self):
+        """Tests getting the path postfix from a route."""
+        self.assertEqual("meta-data/local-hostname", Route(path="/latest/meta-data/local-hostname").path_postfix)
+        self.assertEqual("meta-data/public-keys/", Route(path="/latest/meta-data/public-keys/").path_postfix)

--- a/src/metascrape/pipelines/__init__.py
+++ b/src/metascrape/pipelines/__init__.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from metascrape import items
+
+import json
+import logging
+
+
+class JSONItemPipeline(object):
+    """"""
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        """Construct a new pipeline from the given crawler."""
+        return cls(output_file=crawler.settings.get("JSON_OUTPUT_FILE"))
+
+    def __init__(self, output_file):
+        """Construct a new JSON item pipeline."""
+        self.result = { "routes": {} }
+        self.logger = logging.getLogger("metascrape.pipelines.{}".format(self.__class__.__name__))
+        self.output_file = output_file
+
+    def open_spider(self, spider):
+        """Callback method called when a spider has been opened."""
+        self.logger.debug("Spider %s has been opened.", spider)
+
+    def process_item(self, item, spider):
+        """Process an item received from the spider."""
+        self.logger.debug("Received an item from the %s spider: %s", spider, item)
+
+        if isinstance(item, items.Route):
+            # sanitize the item
+            item.sanitize()
+
+            # extract values
+            path, headers, response, response_encoding = item["path"], item["headers"], item["response"], \
+                item["response_encoding"]
+
+            # insert into output
+            self.result.get('routes')[path] = {
+                'path': path,
+                'headers': headers,
+                'response': response,
+                'response_encoding': response_encoding,
+            }
+
+    def close_spider(self, spider):
+        """Callback method called when a spider is closed."""
+        self.logger.debug("Spider %s has been closed.", spider)
+
+        with open(self.output_file, 'w') as f:
+            f.write(json.dumps(self.result, sort_keys=True, indent=2))

--- a/src/metascrape/spiders/__init__.py
+++ b/src/metascrape/spiders/__init__.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from metascrape.exceptions import WrongServiceException
+from metascrape.items import Route
+from metascrape import utils
+
+import base64
+
+import scrapy
+
+
+class EC2Spider(scrapy.spiders.Spider):
+    """
+    A spider for crawling the EC2 metadata service.
+
+    The EC2 metadata service has a few weird gotchas to understand how to crawl it.
+
+     - The EC2 metadata service will return a header `Server: EC2ws` which can be used to identify it.
+     - The first-level keys contain the different available versions of the service. `latest` is generally what you
+       want. These never end in a slash, yet are directories.
+     - The second-level keys presently contain at max three keys: `dynamic`, `meta-data`, and `user-data` and none of
+       these end in a slash.
+     - Anything at third-level and below will contain a trailing slash if the entry is a directory, and won't if it is
+       just a directory entry.
+     - Most things are text/plain content encoding, with `{version}/user-data` always being application/octet-stream.
+     - Some entries are JSON, yet are text/plain, c.f. `{version}/meta-data/identity-credentials/ec2/info`.
+     - Some entries are weird arrays, c.f. `{version}/meta-data/public-keys/`, which returns values formatted as
+       `{index}={key_name}`. To traverse this array-like entry, the following path should be used:
+       `{version}/meta-data/public-keys/{index}`, which will yield the key name. Next, the key fingerprint can be
+       fetched at `{version}/meta-data/public-keys/{index}/{key_name}. This appears to be the only use of this array
+       format.
+
+    To keep things stupid and simple, our data model will be a JSON dictionary where each key is a key and each value
+    is either a string/byte-array or another dictionary.
+    """
+
+    name = "metascraper.spiders.EC2Spider"
+
+    def __init__(self, metadata_host, metadata_port):
+        """Construct a new spider with the given metadata host and port."""
+        self.metadata_host, self.metadata_port = metadata_host, metadata_port
+
+    def get_url(self, path=None):
+        """Get the request URL for a given path."""
+        return "http://{}:{}/{}".format(self.metadata_host, self.metadata_port, path if path is not None else "")
+
+    def create_route(self, response, path=None):
+        """Given a response, create a route object item."""
+        if path is None or len(path) == 0:
+            path = "/"
+
+        if not path.startswith("/"):
+            path = "/" + path
+
+        if response.headers.get('Content-Type', b"text/plain").decode("utf-8") == "application/octet-stream":
+            body, body_type = base64.encodebytes(response.body).strip().decode('utf-8'), "base64"
+        else:
+            body, body_type = response.text, "text"
+
+        return Route(path=path, headers=utils.extract_headers(response), response=body,
+            response_encoding=body_type)
+
+    def start_requests(self):
+        """Start scraping the given urls."""
+        self.logger.debug("Starting to scrape the EC2 metadata service at %s:%d",
+            self.metadata_host, self.metadata_port)
+
+        return [scrapy.Request(self.get_url(), callback=self.parse_apex)]
+
+    def parse_apex(self, response):
+        """
+        Parse the root URL of the metadata service, yielding each available EC2 metadata service API version.
+        """
+        self.logger.debug("Received index response: %d", response.status)
+
+        if response.headers.get('Server', None) != b'EC2ws':
+            raise WrongServiceException("Expected EC2 metadata service, instead got Server: {}".format(
+                response.headers.get('Server', '(empty)')))
+
+        self.logger.debug("Successfully identified endpoint as EC2 metadata service.")
+
+        yield self.create_route(response, "/")
+
+        for api_version in response.text.splitlines():
+            # each of these is a directory
+            self.logger.debug("Discovered API version %s", api_version)
+
+            yield scrapy.Request(self.get_url(api_version), callback=self.parse_api_data_types,
+                meta={ "path": api_version, "api_version": api_version })
+
+    def parse_api_data_types(self, response):
+        """
+        Parse the available data types for a given API version.
+
+        These are going to be `dynamic`, `meta-data`, and `user-data`, each with its own set of rules.
+        """
+        path, api_version = response.meta.get('path'), response.meta.get('api_version')
+
+        self.logger.debug("Discovered data types for API version %s", api_version)
+
+        yield self.create_route(response, path)
+
+        for data_type in response.text.splitlines():
+            self.logger.debug("Discovered %s/%s data type.", api_version, data_type)
+
+            next_path = "/".join([path, data_type])
+
+            if data_type == "user-data":
+                # user-data is a byte-array and non traversable
+                yield scrapy.Request(self.get_url(next_path), callback=self.parse_user_data,
+                    meta={ 'path': next_path, 'api_version': api_version })
+            else:
+                # everything else (`dynamic` and `meta-data`) should be parsed as a directory structure
+                yield scrapy.Request(self.get_url(next_path), callback=self.parse_directory,
+                    meta={ 'path': next_path + '/', 'api_version': api_version })
+
+    def parse_user_data(self, response):
+        """
+        Parse user data for the given API version.
+
+        This will be `application/octet-stream`, a byte array, though it's typically strings.
+        """
+        path, api_version = response.meta.get('path'), response.meta.get('api_version')
+
+        self.logger.debug("Discovered user-data for API version %s", api_version)
+
+        yield self.create_route(response, path)
+
+    def parse_directory(self, response):
+        """Parse a directory structure."""
+        path, api_version = response.meta.get('path'), response.meta.get('api_version')
+
+        self.logger.debug("Crawling directory %s", path)
+
+        yield self.create_route(response, path)
+
+        for entry in response.text.splitlines():
+            next_path = (path + entry) if path.endswith('/') else "/".join([path, entry])
+
+            if entry.endswith('/'):
+                self.logger.debug("Found a directory: %s", next_path)
+
+                if next_path.endswith('/meta-data/public-keys/'):
+                    # deal with odd public key case
+                    yield scrapy.Request(self.get_url(next_path), callback=self.parse_public_key_dir,
+                        meta={ 'path': next_path, 'api_version': api_version })
+                else:
+                    yield scrapy.Request(self.get_url(next_path), callback=self.parse_directory,
+                        meta={ 'path': next_path, 'api_version': api_version })
+            else:
+                self.logger.debug("Found a 'file': %s", next_path)
+                yield scrapy.Request(self.get_url(next_path), callback=self.parse_file,
+                    meta={ 'path': next_path, 'api_version': api_version })
+
+    def parse_public_key_dir(self, response):
+        """Parse the SSH key metadata."""
+        path, api_version = response.meta.get('path'), response.meta.get('api_version')
+
+        yield self.create_route(response, path)
+
+        for entry in response.text.splitlines():
+            # each entry is of format {index:02d}={key_name}
+            index = entry.split('=')[0]
+
+            # the next path to crawl is {current_path}/{index}/ - note trailing slash
+            next_path = ((path + index) if path.endswith('/') else "/".join([path, index])) + "/"
+
+            yield scrapy.Request(self.get_url(next_path), callback=self.parse_directory,
+                meta={ 'path': next_path, 'api_version': api_version })
+
+    def parse_file(self, response):
+        """Parse a 'file' as listed from a 'directory."""
+        path, api_version = response.meta.get('path'), response.meta.get('api_version')
+
+        self.logger.debug("Parsed Entry: %s: %s", path, str(response.body))
+
+        yield self.create_route(response, path)
+
+    def parse(self, response):
+        """Default callback for processing responses without defined callbacks."""
+        # raise an exception because everything should be explicit
+        raise Exception("NO CALLBACK")

--- a/src/metascrape/utils/__init__.py
+++ b/src/metascrape/utils/__init__.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from datetime import datetime
+
+import logging
+import tzlocal
+
+
+class LoggingFormatter(logging.Formatter):
+    """A custom logging formatter which supports more date formatting options."""
+
+    DEFAULT_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
+
+    TIMEZONE = tzlocal.get_localzone()
+
+    converter = datetime.utcfromtimestamp
+
+    def formatTime(self, record, datefmt=None):
+        """Format time using our custom time formatter."""
+        if not datefmt:
+            datefmt = LoggingFormatter.DEFAULT_DATE_FORMAT
+
+        # by default, no timezone is associated with a datetime, so we create a new one with a timezone
+        record_time = LoggingFormatter.TIMEZONE.localize(self.converter(record.created))
+
+        return "".join([
+            # iso-8601 slug prefix
+            record_time.strftime("%Y-%m-%dT%H:%M:%S"),
+            # microsecond to millisecond conversion
+            ".{:03.0f}".format(record.msecs),
+            # iso-8601 timezone postfix
+            record_time.strftime("%z"),
+        ])
+
+
+def extract_headers(response):
+    """Extract relevant headers from a response into a dictionary."""
+    result = {}
+
+    for key in response.headers.keys():
+        if isinstance(key, bytes):
+            key = key.decode('utf-8')
+
+        value = response.headers.get(key)
+
+        if isinstance(value, bytes):
+            value = value.decode('utf-8')
+
+        if key in ('Date', 'Content-Length', 'Etag','Last-Modified'):
+            continue
+
+        result[key] = value
+
+    return result

--- a/src/metascrape/utils/tests.py
+++ b/src/metascrape/utils/tests.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from metascrape import utils
+
+import mock
+import unittest
+
+
+class UtilsTestCase(unittest.TestCase):
+
+    def test_extract_headers(self):
+        mock_response = mock.Mock()
+
+        mock_response.headers = {
+            "Accept-Ranges": "none",
+            "Connection": "close",
+            "Content-Length": "230",
+            "Content-Type": "text/plain",
+            "Date": "Mon, 15 Jul 2019 19:43:30 GMT",
+            "Etag": "abcdefg",
+            "Last-Modified": "Thu, 11 Jul 2019 23:18:47 GMT",
+            "Server": "EC2ws",
+        }
+
+        result = utils.extract_headers(mock_response)
+
+        self.assertNotIn('Content-Length', result.keys())
+        self.assertNotIn('Date', result.keys())
+        self.assertNotIn('Etag', result.keys())
+        self.assertNotIn('Last-Modified', result.keys())
+
+        self.assertIn('Server', result.keys())

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -3,6 +3,17 @@
   hosts: all
   become: true
   roles:
+    - role: terraform
+      version: 0.12.4
     - role: vagrant-docker
     - role: vagrant-python-dev
       python_version: 3.7.4
+  tasks:
+    - name: allow aws environment variables across the wire
+      lineinfile:
+        dest: /etc/ssh/sshd_config
+        line: AcceptEnv AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+      notify: restart ssh
+  handlers:
+    - name: restart ssh
+      service: name=sshd state=restarted


### PR DESCRIPTION
### TODO 

 - [x] Successfully traverse API versions (level 0).
 - [x] Successfully traverse data types (level 1).
 - [x] Successfully traverse directories and entries (level 2+).
 - [x] Successfully deal with SSH keys exception case
 - [x] Add a sanitizer for certain values.
 - [x] Store relevant response headers.

### Values to Sanitize

 - [x] IAM Credentials: parse as JSON, replace access/secret/token, reserialize to JSON (`/${api_version}/meta-data/identity-credentials/ec2/security-credentials/ec2-instance`)
 - [x] Sanitize identifiers such as VPC, EC2 instance ids.
 - [x] Sanitize account ids.
 - [x] Sanitize internal IP addresses.
 - [x] Sanitize external IP addresses.
 - [x] Sanitize MAC addresses.
 - [x] Sanitize hostnames.
 - [x] Sanitize `/${api_version}/dynamic/instance-identity/pkcs7` (base 64)
 - [x] Sanitize `/${api_version}/dynamic/instance-identity/rsa2048` (base 64)
 - [x] Sanitize `/${api_version}/dynamic/instance-identity/signature` (base 64)

Need to get access to internal testing account so that we don't need to sanitize VPC, SG, subnet, ENI, EC2 ids.